### PR TITLE
Bind to an ipv6 address.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "basic_tcp_proxy"
 description = "Simple synchronous TCP proxy crate for forwarding TCP connections"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use log::debug;
 use std::io::{BufRead, BufReader, Write};
 use std::net::SocketAddr;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv6Addr};
 use std::net::{TcpListener, TcpStream};
 
 /// TcpProxy runs one thread looping to accept new connections
@@ -20,11 +20,11 @@ impl TcpProxy {
         local_only: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let ip = if local_only {
-            Ipv4Addr::new(127, 0, 0, 1)
+            Ipv6Addr::LOCALHOST
         } else {
-            Ipv4Addr::new(0, 0, 0, 0)
+            Ipv6Addr::UNSPECIFIED
         };
-        let listener_forward = TcpListener::bind(SocketAddr::new(IpAddr::V4(ip), listen_port))?;
+        let listener_forward = TcpListener::bind(SocketAddr::new(IpAddr::V6(ip), listen_port))?;
 
         let forward_thread = std::thread::spawn(move || {
             loop {


### PR DESCRIPTION
This PR changes the binding to bind to an ipv6 address instead of an ipv4 address. As far as I can see, ipv4 addresses are redirected to ipv6 addresses so this works for both ipv4 and ipv6.